### PR TITLE
fixes date formats messing up everything after it

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -1,4 +1,4 @@
-const dateTmplRegex = /{{DATE:(.+)}}/gm
+const dateTmplRegex = /{{DATE:([^}]+)}}/gm
 
 const replaceDateVar = (s: string, date: moment.Moment): string => {
 	const m = dateTmplRegex.exec(s)


### PR DESCRIPTION
made date format regex stop at the first right curly brackets by replacing "any character" with "any character that's not }" this allows one to put other {{things}} after a date block without date regex matching both of them.

addresses bug 16: https://github.com/reorx/obsidian-paste-image-rename/issues/16